### PR TITLE
Fix typescript return value errors

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import { runQuery, getQuery } from '../config/database';
 import { generateToken } from '../middleware/auth';
+import jwt from 'jsonwebtoken';
 
 const router = Router();
 
@@ -66,7 +67,7 @@ router.post('/register', validateRegistration, async (req, res, next) => {
     // Generate token
     const token = generateToken(userId);
 
-    res.status(201).json({
+    return res.status(201).json({
       success: true,
       data: {
         token,
@@ -78,7 +79,7 @@ router.post('/register', validateRegistration, async (req, res, next) => {
       }
     });
   } catch (error) {
-    next(error);
+    return next(error);
   }
 });
 
@@ -121,7 +122,7 @@ router.post('/login', validateLogin, async (req, res, next) => {
     // Generate token
     const token = generateToken(user.id);
 
-    res.json({
+    return res.json({
       success: true,
       data: {
         token,
@@ -133,7 +134,7 @@ router.post('/login', validateLogin, async (req, res, next) => {
       }
     });
   } catch (error) {
-    next(error);
+    return next(error);
   }
 });
 
@@ -150,7 +151,6 @@ router.get('/me', async (req, res, next) => {
       });
     }
 
-    import jwt from 'jsonwebtoken';
     const jwtSecret = process.env.JWT_SECRET;
     
     if (!jwtSecret) {
@@ -171,7 +171,7 @@ router.get('/me', async (req, res, next) => {
       });
     }
 
-    res.json({
+    return res.json({
       success: true,
       data: {
         user: {
@@ -189,7 +189,7 @@ router.get('/me', async (req, res, next) => {
         error: 'Invalid token'
       });
     }
-    next(error);
+    return next(error);
   }
 });
 


### PR DESCRIPTION
Add `return` statements to all response and error handling paths and move `jwt` import to resolve TS7030 compilation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-9161bbac-25cb-4e10-96c2-28e3d255a008">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9161bbac-25cb-4e10-96c2-28e3d255a008">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

